### PR TITLE
Wasm binary size logging

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -78,8 +78,10 @@ pub fn run(script_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResul
     let output: serde_json::Value = serde_json::from_slice(output.as_slice())
         .map_err(|e| anyhow!("Couldn't decode Script Output: {}", e))?;
 
+    let size = script_path.metadata()?.len();
+
     let function_run_result =
-        FunctionRunResult::new(runtime, memory_usage, output, logs.to_string());
+        FunctionRunResult::new(runtime, size, memory_usage, output, logs.to_string());
 
     Ok(function_run_result)
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -108,6 +108,7 @@ mod tests {
     const FUNCTION_SLEEP_DURATION: Duration = Duration::from_millis(42);
     const HELLO_WORLD_MEMORY_USAGE: u64 = 17;
     const MODIFIED_HELLO_WORLD_MEMORY_USAGE: u64 = 42;
+    const HELLO_WORLD_FILE_SIZE: u64 = 113443;
 
     #[test]
     fn test_runtime_over_threshold() {
@@ -153,5 +154,16 @@ mod tests {
         );
 
         assert!(function_run_result.is_err());
+    }
+
+    #[test]
+    fn test_file_size() {
+        let function_run_result = run(
+            Path::new("tests/benchmarks/hello_world.wasm").to_path_buf(),
+            Path::new("tests/benchmarks/hello_world.json").to_path_buf(),
+        )
+        .unwrap();
+
+        assert_eq!(function_run_result.size, HELLO_WORLD_FILE_SIZE);
     }
 }

--- a/src/function_run_result.rs
+++ b/src/function_run_result.rs
@@ -3,6 +3,7 @@ use std::{fmt, time::Duration};
 
 pub struct FunctionRunResult {
     pub runtime: Duration,
+    pub size: u64,
     pub memory_usage: u64,
     pub logs: String,
     pub output: serde_json::Value,
@@ -11,12 +12,14 @@ pub struct FunctionRunResult {
 impl FunctionRunResult {
     pub fn new(
         runtime: Duration,
+        size: u64,
         memory_usage: u64,
         output: serde_json::Value,
         logs: String,
     ) -> Self {
         FunctionRunResult {
             runtime,
+            size,
             memory_usage,
             output,
             logs,
@@ -30,7 +33,8 @@ impl fmt::Display for FunctionRunResult {
         write!(f, "{}\n\n", title)?;
 
         writeln!(f, "Runtime: {:?}", self.runtime)?;
-        writeln!(f, "Memory Usage: {}KB\n", self.memory_usage * 64)?;
+        writeln!(f, "Memory Usage: {}KB", self.memory_usage * 64)?;
+        writeln!(f, "Size: {}KB\n", self.size / 1024)?;
 
         writeln!(
             f,


### PR DESCRIPTION
### What are you trying to accomplish?

The run function now calculates the size of the wasm binary and logs it.

### The impact of these changes

#### On Shopify

The Function dev can now see the size of the file alongside all the other logs.

#### On merchants

No change

#### On third-party apps

Same as Shopify.

### Tophat 🎩

You can test your own script by running `cargo run --release -- <path/to/input.json> -s <path/to/script.wasm>`.

Note that `--release` is mandatory to benchmark since the runtime is much shorter when the binary is optimized.

Additionally, I wrote automated tests (that are executed in an opt-3 environment), so `cargo test` will show the results of these tests.

## Before you deploy

- [x] I [tophatted](https://development.shopify.io/engineering/developing_at_Shopify/write-code/tophatting) or tested this change.