### PR TITLE
fix: changed scripts to functions for docs/args

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,18 +14,18 @@ jobs:
         include:
           - name: linux
             os: ubuntu-latest
-            path: target/release/script-runner
-            asset_name: script-runner-x86_64-linux-${{ github.event.release.tag_name }}
+            path: target/release/function-runner
+            asset_name: function-runner-x86_64-linux-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
           - name: macos
             os: macos-latest
-            path: target/release/script-runner
-            asset_name: script-runner-x86_64-macos-${{ github.event.release.tag_name }}
+            path: target/release/function-runner
+            asset_name: function-runner-x86_64-macos-${{ github.event.release.tag_name }}
             shasum_cmd: shasum -a 256
           - name: windows
             os: windows-latest
-            path: target\release\script-runner.exe
-            asset_name: script-runner-x86_64-windows-${{ github.event.release.tag_name }}
+            path: target\release\function-runner.exe
+            asset_name: function-runner-x86_64-windows-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
 
     steps:
@@ -39,7 +39,7 @@ jobs:
           default: true
 
       - name: Build ${{ matrix.os }}
-        run: cargo build --release --package script-runner
+        run: cargo build --release --package function-runner
 
       - name: Archive assets
         run: gzip -k -f ${{ matrix.path }} && mv ${{ matrix.path }}.gz ${{ matrix.asset_name }}.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /target
-script-runner-*.gz*
+function-runner-*.gz*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,28 +3,28 @@
 1. From the `main` branch, set an environment variable to the version number with the format `v{version_number}` (e.g. `v0.1.0`). This should match the version number in `Cargo.toml`.
 
 ```sh
-export SCRIPT_RUNNER_VERSION=v0.1.0
+export FUNCTION=v0.1.0
 ```
 
 2. Create a new tag.
 
 ```sh
-git tag $SCRIPT_RUNNER_VERSION
+git tag $FUNCTION_RUNNER_VERSION
 git push origin --tags
 ```
 
-2. Create a new Github release [here](https://github.com/Shopify/script-runner/releases/new).
-3. When the release is created, the Github action defined in `publish.yml` will be run. This will produce the build artifacts for script-runner, except for `arm-macos` (e.g. M1 Macs).
-4. Build `script-runner` on an ARM Mac (e.g. M1 Mac)
+2. Create a new Github release [here](https://github.com/Shopify/function-runner/releases/new).
+3. When the release is created, the Github action defined in `publish.yml` will be run. This will produce the build artifacts for function-runner, except for `arm-macos` (e.g. M1 Macs).
+4. Build `function-runner` on an ARM Mac (e.g. M1 Mac)
 
 ```sh
-cargo build --release --package script-runner && gzip -k -f target/release/script-runner && mv target/release/script-runner.gz script-runner-arm-macos-$SCRIPT_RUNNER_VERSION.gz
+cargo build --release --package function-runner && gzip -k -f target/release/function-runner && mv target/release/function-runner.gz function-runner-arm-macos-$FUNCTION_RUNNER_VERSION.gz
 ```
 
 5. Create the shasum file
 
 ```sh
-shasum -a 256 script-runner-arm-macos-$SCRIPT_RUNNER_VERSION.gz | awk '{ print $1 }' > script-runner-arm-macos-$SCRIPT_RUNNER_VERSION.gz.sha256
+shasum -a 256 function-runner-arm-macos-$FUNCTION_RUNNER_VERSION.gz | awk '{ print $1 }' > function-runner-arm-macos-$FUNCTION_RUNNER_VERSION.gz.sha256
 ```
 
 6. Attach the build and shasum to the release created in step 2.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "function-runner"
+version = "0.2.3"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "deterministic-wasi-ctx",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasi-common",
+ "wasmtime",
+ "wasmtime-wasi",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,22 +1100,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "script-runner"
-version = "0.2.3"
-dependencies = [
- "anyhow",
- "clap",
- "colored",
- "deterministic-wasi-ctx",
- "serde",
- "serde_derive",
- "serde_json",
- "wasi-common",
- "wasmtime",
- "wasmtime-wasi",
-]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "script-runner"
+name = "function-runner"
 version = "0.2.3"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,46 @@
-# script-runner
+# function-runner
 
 [About this repo](#about-this-repo) |  [Commands](#commands-optional) | [How to use this repo](#how-to-use-this-repo)
 
 ## About this repo
 **Introduction:**
 
-This is a simple CLI (`script-runner`) which allows you to run Wasm
-scripts intended for ShopifyVM. Scripts will run using
+This is a simple CLI (`function-runner`) which allows you to run Wasm
+Functions intended for the Shopify Functions infrastructure. Functions will run using
 the provided JSON input file and their output will be printed as JSON
 upon completion.
 
-By default, the script is expected to be named `script.wasm` in the
-current directory. This may be overriden using the `-s` option.
+By default, the Function is expected to be named `function.wasm` in the
+current directory. This may be overriden using the `-f` option.
 
-Example: `script-runner -s '../my-script-name.wasm' '../my-input.json'`
+Example: `function-runner -s '../my-function-name.wasm' '../my-input.json'`
 
 ## Commands (optional)
 
-* `cargo install --path .` : Build and install the `script-runner` command.
-* `script-runner` : Execute scripts.
+* `cargo install --path .` : Build and install the `function-runner` command.
+* `function-runner` : Execute Functions.
 
 ## How to use this repo
 
 Building requires a rust toolchain of at least `1.56.0` (older may work). `cargo install --path .` will build
-and add the `script-runner` command to your path.
+and add the `function-runner` command to your path.
 
 ### Usage
+
 ```
-$ script-runner --help
-script-runner 0.2.3
-Simple script runner which takes JSON as a convenience
+$ function-runner --help
+function-runner 0.2.3
+Simple function runner which takes JSON as a convenience
 
 USAGE:
-    script-runner [OPTIONS] <INPUT>
+    function-runner [OPTIONS] <INPUT>
 
 ARGS:
-    <INPUT>    Path to json file containing script input
+    <INPUT>    Path to json file containing function input
 
 OPTIONS:
     -h, --help               Print help information
     -j, --json               Log the run result as a JSON object
-    -s, --script <SCRIPT>    Path to wasm/wat script [default: script.wasm]
+    -f, --function <FUNCTION>    Path to wasm/wat function [default: function.wasm]
     -V, --version            Print version information
 ```

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,10 +7,10 @@ use wasmtime::{Engine, Linker, Module, Store};
 
 use crate::function_run_result::FunctionRunResult;
 
-pub fn run(script_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResult> {
+pub fn run(function_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResult> {
     let engine = Engine::default();
-    let module = Module::from_file(&engine, &script_path)
-        .map_err(|e| anyhow!("Couldn't load script {:?}: {}", &script_path, e))?;
+    let module = Module::from_file(&engine, &function_path)
+        .map_err(|e| anyhow!("Couldn't load the Function {:?}: {}", &function_path, e))?;
 
     let input: serde_json::Value = serde_json::from_reader(
         std::fs::File::open(&input_path)
@@ -78,18 +78,17 @@ pub fn run(script_path: PathBuf, input_path: PathBuf) -> Result<FunctionRunResul
         .expect("Error stream reference still exists")
         .into_inner();
     let logs =
-        std::str::from_utf8(&logs).map_err(|e| anyhow!("Couldn't print Script Logs: {}", e))?;
+        std::str::from_utf8(&logs).map_err(|e| anyhow!("Couldn't print Function Logs: {}", e))?;
 
     let output = output_stream
         .try_into_inner()
         .expect("Output stream reference still exists")
         .into_inner();
     let output: serde_json::Value = serde_json::from_slice(output.as_slice())
-        .map_err(|e| anyhow!("Couldn't decode Script Output: {}", e))?;
+        .map_err(|e| anyhow!("Couldn't decode Function Output: {}", e))?;
 
-    // get the script file name
-    let name = script_path.file_name().unwrap().to_str().unwrap();
-    let size = script_path.metadata()?.len();
+    let name = function_path.file_name().unwrap().to_str().unwrap();
+    let size = function_path.metadata()?.len();
 
     let function_run_result = FunctionRunResult::new(
         name.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,17 +2,17 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use script_runner::engine::run;
+use function_runner::engine::run;
 
-/// Simple script runner which takes JSON as a convenience.
+/// Simple Function runner which takes JSON as a convenience.
 #[derive(Parser)]
 #[clap(version)]
 struct Opts {
-    /// Path to wasm/wat script
-    #[clap(short, long, default_value = "script.wasm")]
-    script: PathBuf,
+    /// Path to wasm/wat Function
+    #[clap(short, long, default_value = "function.wasm")]
+    function: PathBuf,
 
-    /// Path to json file containing script input
+    /// Path to json file containing Function input
     input: PathBuf,
 
     /// Log the run result as a JSON object
@@ -23,7 +23,7 @@ struct Opts {
 fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
 
-    let function_run_result = run(opts.script, opts.input)?;
+    let function_run_result = run(opts.function, opts.input)?;
 
     if opts.json {
         println!("{}", function_run_result.to_json());


### PR DESCRIPTION
## What

Changed naming of scripts to Functions, as well as for the flags. Now its `-f`/`--function` instead of `-s`/`--script` to specify the chosen function.

### Checklist

#### Before Merging

- [x] I have 🎩'd this locally
- [x] If this is complex to 🎩, I have provided instructions for others

After merging, the name of the repo will be changed to function-runner.